### PR TITLE
Add support for all types of 1:1, 1:n, and n:m associations

### DIFF
--- a/lib/userlist/rails.rb
+++ b/lib/userlist/rails.rb
@@ -60,7 +60,7 @@ module Userlist
     end
 
     def self.find_association_between(from, to)
-      association = Userlist::Rails.find_reflection(from, to)
+      return unless association = Userlist::Rails.find_reflection(from, to)
 
       association.through_reflection || association
     end

--- a/lib/userlist/rails.rb
+++ b/lib/userlist/rails.rb
@@ -59,6 +59,12 @@ module Userlist
       from.reflect_on_all_associations.find { |r| r.class_name == to.to_s }
     end
 
+    def self.find_association_between(from, to)
+      association = Userlist::Rails.find_reflection(from, to)
+
+      association.through_reflection || association
+    end
+
     def self.setup_callbacks(model, scope)
       return if model.instance_variable_get(:@userlist_callbacks_registered)
 

--- a/lib/userlist/rails/transform.rb
+++ b/lib/userlist/rails/transform.rb
@@ -11,7 +11,7 @@ module Userlist
       end
 
       def [](name)
-        public_send(name) if key?(name)
+        model.try("userlist_#{name}") || public_send("default_#{name}") if key?(name)
       end
 
       def key?(name)

--- a/lib/userlist/rails/transform.rb
+++ b/lib/userlist/rails/transform.rb
@@ -34,12 +34,8 @@ module Userlist
         (!model.respond_to?(:userlist_delete?) || model.userlist_delete?)
       end
 
-    private
-
-      attr_reader :model, :config
-
-      def auto_detect_relationships(from, to)
-        association = Userlist::Rails.find_association_between(from, to)
+      def default_relationships
+        association = Userlist::Rails.find_association_between(relationship_from, relationship_to)
 
         records = Array.wrap(model.try(association&.name))
 
@@ -50,7 +46,19 @@ module Userlist
         end
       end
 
+    private
+
+      attr_reader :model, :config
+
       def build_relationship(_record)
+        raise NotImplementedError
+      end
+
+      def relationship_to
+        raise NotImplementedError
+      end
+
+      def relationship_from
         raise NotImplementedError
       end
     end

--- a/lib/userlist/rails/transform.rb
+++ b/lib/userlist/rails/transform.rb
@@ -37,6 +37,22 @@ module Userlist
     private
 
       attr_reader :model, :config
+
+      def auto_detect_relationships(from, to)
+        association = Userlist::Rails.find_association_between(from, to)
+
+        records = Array.wrap(model.try(association&.name))
+
+        if association.klass == config.relationship_model
+          records
+        else
+          records.map { |record| build_relationship(record) }
+        end
+      end
+
+      def build_relationship(_record)
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/userlist/rails/transform.rb
+++ b/lib/userlist/rails/transform.rb
@@ -34,33 +34,9 @@ module Userlist
         (!model.respond_to?(:userlist_delete?) || model.userlist_delete?)
       end
 
-      def default_relationships
-        association = Userlist::Rails.find_association_between(relationship_from, relationship_to)
-
-        records = Array.wrap(model.try(association&.name))
-
-        if association.klass == config.relationship_model
-          records
-        else
-          records.map { |record| build_relationship(record) }
-        end
-      end
-
     private
 
       attr_reader :model, :config
-
-      def build_relationship(_record)
-        raise NotImplementedError
-      end
-
-      def relationship_to
-        raise NotImplementedError
-      end
-
-      def relationship_from
-        raise NotImplementedError
-      end
     end
   end
 end

--- a/lib/userlist/rails/transforms/company.rb
+++ b/lib/userlist/rails/transforms/company.rb
@@ -23,9 +23,7 @@ module Userlist
         end
 
         def relationships
-          relationships_method = Userlist::Rails.find_reflection(config.company_model, config.relationship_model)&.name
-
-          model.try(:userlist_relationships) || (relationships_method && model.try(relationships_method))
+          model.try(:userlist_relationships) || auto_detect_relationships(config.company_model, config.user_model)
         end
 
         def name
@@ -34,6 +32,12 @@ module Userlist
 
         def signed_up_at
           model.try(:created_at)
+        end
+
+      private
+
+        def build_relationship(record)
+          { user: record }
         end
       end
     end

--- a/lib/userlist/rails/transforms/company.rb
+++ b/lib/userlist/rails/transforms/company.rb
@@ -14,23 +14,23 @@ module Userlist
           ]
         end
 
-        def identifier
-          model.try(:userlist_identifier) || "#{model.class.name}-#{model.id}".parameterize
+        def default_identifier
+          "#{model.class.name}-#{model.id}".parameterize
         end
 
-        def properties
-          model.try(:userlist_properties) || {}
+        def default_properties
+          {}
         end
 
-        def relationships
-          model.try(:userlist_relationships) || auto_detect_relationships(config.company_model, config.user_model)
+        def default_relationships
+          auto_detect_relationships(config.company_model, config.user_model)
         end
 
-        def name
-          model.try(:userlist_name) || model.try(:name)
+        def default_name
+          model.try(:name)
         end
 
-        def signed_up_at
+        def default_signed_up_at
           model.try(:created_at)
         end
 

--- a/lib/userlist/rails/transforms/company.rb
+++ b/lib/userlist/rails/transforms/company.rb
@@ -22,10 +22,6 @@ module Userlist
           {}
         end
 
-        def default_relationships
-          auto_detect_relationships(config.company_model, config.user_model)
-        end
-
         def default_name
           model.try(:name)
         end
@@ -38,6 +34,14 @@ module Userlist
 
         def build_relationship(record)
           { user: record }
+        end
+
+        def relationship_from
+          config.company_model
+        end
+
+        def relationship_to
+          config.user_model
         end
       end
     end

--- a/lib/userlist/rails/transforms/company.rb
+++ b/lib/userlist/rails/transforms/company.rb
@@ -1,9 +1,12 @@
 require 'userlist/rails/transform'
+require 'userlist/rails/transforms/has_relationships'
 
 module Userlist
   module Rails
     module Transforms
       class Company < Userlist::Rails::Transform
+        include HasRelationships
+
         def self.attributes
           @attributes ||= [
             :identifier,

--- a/lib/userlist/rails/transforms/has_relationships.rb
+++ b/lib/userlist/rails/transforms/has_relationships.rb
@@ -5,14 +5,14 @@ module Userlist
     module Transforms
       module HasRelationships
         def default_relationships
-          association = Userlist::Rails.find_association_between(relationship_from, relationship_to)
+          return unless association = Userlist::Rails.find_association_between(relationship_from, relationship_to)
 
-          records = Array.wrap(model.try(association&.name))
+          records = model.try(association.name)
 
           if association.klass == config.relationship_model
             records
           else
-            records.map { |record| build_relationship(record) }
+            Array.wrap(records).map { |record| build_relationship(record) }
           end
         end
 

--- a/lib/userlist/rails/transforms/has_relationships.rb
+++ b/lib/userlist/rails/transforms/has_relationships.rb
@@ -1,0 +1,35 @@
+require 'userlist/rails/transform'
+
+module Userlist
+  module Rails
+    module Transforms
+      module HasRelationships
+        def default_relationships
+          association = Userlist::Rails.find_association_between(relationship_from, relationship_to)
+
+          records = Array.wrap(model.try(association&.name))
+
+          if association.klass == config.relationship_model
+            records
+          else
+            records.map { |record| build_relationship(record) }
+          end
+        end
+
+      private
+
+        def build_relationship(_record)
+          raise NotImplementedError
+        end
+
+        def relationship_to
+          raise NotImplementedError
+        end
+
+        def relationship_from
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/userlist/rails/transforms/relationship.rb
+++ b/lib/userlist/rails/transforms/relationship.rb
@@ -12,20 +12,20 @@ module Userlist
           ]
         end
 
-        def properties
-          model.try(:userlist_properties) || {}
+        def default_properties
+          {}
         end
 
-        def user
+        def default_user
           user_method = Userlist::Rails.find_reflection(config.relationship_model, config.user_model)&.name
 
-          model.try(:userlist_user) || (user_method && model.try(user_method))
+          user_method && model.try(user_method)
         end
 
-        def company
+        def default_company
           company_method = Userlist::Rails.find_reflection(config.relationship_model, config.company_model)&.name
 
-          model.try(:userlist_company) || (company_method && model.try(company_method))
+          company_method && model.try(company_method)
         end
       end
     end

--- a/lib/userlist/rails/transforms/user.rb
+++ b/lib/userlist/rails/transforms/user.rb
@@ -22,10 +22,6 @@ module Userlist
           {}
         end
 
-        def default_relationships
-          auto_detect_relationships(config.user_model, config.company_model)
-        end
-
         def default_email
           model.try(:email)
         end
@@ -38,6 +34,14 @@ module Userlist
 
         def build_relationship(record)
           { company: record }
+        end
+
+        def relationship_from
+          config.user_model
+        end
+
+        def relationship_to
+          config.company_model
         end
       end
     end

--- a/lib/userlist/rails/transforms/user.rb
+++ b/lib/userlist/rails/transforms/user.rb
@@ -1,9 +1,12 @@
 require 'userlist/rails/transform'
+require 'userlist/rails/transforms/has_relationships'
 
 module Userlist
   module Rails
     module Transforms
       class User < Userlist::Rails::Transform
+        include HasRelationships
+
         def self.attributes
           @attributes ||= [
             :identifier,

--- a/lib/userlist/rails/transforms/user.rb
+++ b/lib/userlist/rails/transforms/user.rb
@@ -14,23 +14,23 @@ module Userlist
           ]
         end
 
-        def identifier
-          model.try(:userlist_identifier) || "#{model.class.name}-#{model.id}".parameterize
+        def default_identifier
+          "#{model.class.name}-#{model.id}".parameterize
         end
 
-        def properties
-          model.try(:userlist_properties) || {}
+        def default_properties
+          {}
         end
 
-        def relationships
-          model.try(:userlist_relationships) || auto_detect_relationships(config.user_model, config.company_model)
+        def default_relationships
+          auto_detect_relationships(config.user_model, config.company_model)
         end
 
-        def email
-          model.try(:userlist_email) || model.try(:email)
+        def default_email
+          model.try(:email)
         end
 
-        def signed_up_at
+        def default_signed_up_at
           model.try(:created_at)
         end
 

--- a/lib/userlist/rails/transforms/user.rb
+++ b/lib/userlist/rails/transforms/user.rb
@@ -23,9 +23,7 @@ module Userlist
         end
 
         def relationships
-          relationships_method = Userlist::Rails.find_reflection(config.user_model, config.relationship_model)&.name
-
-          model.try(:userlist_relationships) || (relationships_method && model.try(relationships_method))
+          model.try(:userlist_relationships) || auto_detect_relationships(config.user_model, config.company_model)
         end
 
         def email
@@ -34,6 +32,12 @@ module Userlist
 
         def signed_up_at
           model.try(:created_at)
+        end
+
+      private
+
+        def build_relationship(record)
+          { company: record }
         end
       end
     end

--- a/spec/support/dummies.rb
+++ b/spec/support/dummies.rb
@@ -3,33 +3,99 @@ ActiveRecord::Schema.define do
 
   create_table :users, force: true do |t|
     t.string :email
+    t.references :company
     t.timestamps
   end
 
   create_table :companies, force: true do |t|
     t.string :name
+    t.references :user
     t.timestamps
   end
 
   create_table :memberships, force: true do |t|
+    t.string :role
     t.references :user
     t.references :company
-    t.string :role
+    t.timestamps
+  end
+
+  create_table :companies_users, force: true do |t|
+    t.references :user
+    t.references :company
     t.timestamps
   end
 end
 
 class User < ActiveRecord::Base
-  has_many :memberships
-  has_many :companies, through: :memberships
 end
 
 class Company < ActiveRecord::Base
-  has_many :memberships
-  has_many :users, through: :memberships
 end
 
-class Membership < ActiveRecord::Base
-  belongs_to :user
-  belongs_to :company
+module HasManyThrough
+  class User < ActiveRecord::Base
+    has_many :memberships, class_name: 'HasManyThrough::Membership'
+    has_many :companies, through: :memberships, class_name: 'HasManyThrough::Company'
+  end
+
+  class Company < ActiveRecord::Base
+    has_many :memberships, class_name: 'HasManyThrough::Membership'
+    has_many :users, through: :memberships, class_name: 'HasManyThrough::User'
+  end
+
+  class Membership < ActiveRecord::Base
+    belongs_to :user, class_name: 'HasManyThrough::User'
+    belongs_to :company, class_name: 'HasManyThrough::Company'
+  end
+end
+
+module HasAndBelongsToMany
+  class User < ActiveRecord::Base
+    has_and_belongs_to_many :companies, class_name: 'HasAndBelongsToMany::Company'
+  end
+
+  class Company < ActiveRecord::Base
+    has_and_belongs_to_many :users, class_name: 'HasAndBelongsToMany::User'
+  end
+end
+
+module HasManyCompanies
+  class User < ActiveRecord::Base
+    has_many :companies, class_name: 'HasManyCompanies::Company'
+  end
+
+  class Company < ActiveRecord::Base
+    belongs_to :user, class_name: 'HasManyCompanies::User'
+  end
+end
+
+module HasOneCompany
+  class User < ActiveRecord::Base
+    has_one :company, class_name: 'HasOneCompany::Company'
+  end
+
+  class Company < ActiveRecord::Base
+    belongs_to :user, class_name: 'HasOneCompany::User'
+  end
+end
+
+module HasManyUsers
+  class User < ActiveRecord::Base
+    belongs_to :company, class_name: 'HasManyUsers::Company'
+  end
+
+  class Company < ActiveRecord::Base
+    has_many :users, class_name: 'HasManyUsers::User'
+  end
+end
+
+module HasOneUser
+  class User < ActiveRecord::Base
+    belongs_to :company, class_name: 'HasOneUser::Company'
+  end
+
+  class Company < ActiveRecord::Base
+    has_one :user, class_name: 'HasOneUser::User'
+  end
 end

--- a/spec/userlist/rails/transforms/company_spec.rb
+++ b/spec/userlist/rails/transforms/company_spec.rb
@@ -6,46 +6,31 @@ RSpec.describe Userlist::Rails::Transforms::Company do
 
   subject { described_class.new(company, config) }
 
-  describe '#identifier' do
+  describe '#default_identifier' do
     it 'should generate a default identifier' do
-      expect(subject.identifier).to eq("company-#{company.id}")
-    end
-
-    it 'should use the userlist_identifier method' do
-      company.define_singleton_method(:userlist_identifier) { 'test-identifier' }
-      expect(subject.identifier).to eq('test-identifier')
+      expect(subject.default_identifier).to eq("company-#{company.id}")
     end
   end
 
-  describe '#properties' do
+  describe '#default_properties' do
     it 'should generate a default properties hash' do
-      expect(subject.properties).to eq({})
-    end
-
-    it 'should use the userlist_properties method' do
-      company.define_singleton_method(:userlist_properties) { { testing: true } }
-      expect(subject.properties).to eq({ testing: true })
+      expect(subject.default_properties).to eq({})
     end
   end
 
-  describe '#name' do
+  describe '#default_name' do
     it 'should use the models name column' do
-      expect(subject.name).to eq(company.name)
-    end
-
-    it 'should use the userlist_name method' do
-      company.define_singleton_method(:userlist_name) { 'Test, Inc.' }
-      expect(subject.name).to eq('Test, Inc.')
+      expect(subject.default_name).to eq(company.name)
     end
   end
 
-  describe '#signed_up_at' do
+  describe '#default_signed_up_at' do
     it 'should use the created_at attribute as signed_up_at method' do
-      expect(subject.signed_up_at).to eq(company.created_at)
+      expect(subject.default_signed_up_at).to eq(company.created_at)
     end
   end
 
-  describe '#relationships' do
+  describe '#default_relationships' do
     let(:config) { Userlist.config.merge(user_model: scope::User, company_model: scope::Company) }
     let(:company) { scope::Company.create(name: 'Example, Inc.') }
     let(:user) { scope::User.create(email: 'foo@example.com') }
@@ -59,7 +44,7 @@ RSpec.describe Userlist::Rails::Transforms::Company do
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq(company.memberships)
+        expect(subject.default_relationships).to eq(company.memberships)
       end
     end
 
@@ -68,12 +53,10 @@ RSpec.describe Userlist::Rails::Transforms::Company do
 
       before do
         company.users << user
-
-        puts company.users.inspect
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq(company.users.map { |user| { user: user } })
+        expect(subject.default_relationships).to eq(company.users.map { |user| { user: user } })
       end
     end
 
@@ -85,7 +68,7 @@ RSpec.describe Userlist::Rails::Transforms::Company do
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq(company.users.map { |user| { user: user } })
+        expect(subject.default_relationships).to eq(company.users.map { |user| { user: user } })
       end
     end
 
@@ -97,7 +80,7 @@ RSpec.describe Userlist::Rails::Transforms::Company do
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq([{ user: company.user }])
+        expect(subject.default_relationships).to eq([{ user: company.user }])
       end
     end
 
@@ -109,7 +92,7 @@ RSpec.describe Userlist::Rails::Transforms::Company do
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq([{ user: company.user }])
+        expect(subject.default_relationships).to eq([{ user: company.user }])
       end
     end
   end

--- a/spec/userlist/rails/transforms/company_spec.rb
+++ b/spec/userlist/rails/transforms/company_spec.rb
@@ -31,15 +31,25 @@ RSpec.describe Userlist::Rails::Transforms::Company do
   end
 
   describe '#default_relationships' do
-    let(:config) { Userlist.config.merge(user_model: scope::User, company_model: scope::Company) }
-    let(:company) { scope::Company.create(name: 'Example, Inc.') }
-    let(:user) { scope::User.create(email: 'foo@example.com') }
+    let(:config) { Userlist.config.merge(user_model: user_model, company_model: company_model) }
+    let(:user) { user_model.create(email: 'foo@example.com') }
+    let(:company) { company_model.create(name: 'Example, Inc.') }
+
+    context 'when there are no relationships' do
+      let(:user_model) { User }
+      let(:company_model) { Company }
+
+      it 'should return nothing' do
+        expect(subject.default_relationships).to_not be
+      end
+    end
 
     context 'when it is a has many through relationship' do
-      let(:scope) { HasManyThrough }
+      let(:user_model) { HasManyThrough::User }
+      let(:company_model) { HasManyThrough::Company }
 
       before do
-        config.relationship_model = scope::Membership
+        config.relationship_model = HasManyThrough::Membership
         company.memberships.create!(user: user)
       end
 
@@ -49,7 +59,8 @@ RSpec.describe Userlist::Rails::Transforms::Company do
     end
 
     context 'when it is a has and belongs to many relationship' do
-      let(:scope) { HasAndBelongsToMany }
+      let(:user_model) { HasAndBelongsToMany::User }
+      let(:company_model) { HasAndBelongsToMany::Company }
 
       before do
         company.users << user
@@ -61,7 +72,8 @@ RSpec.describe Userlist::Rails::Transforms::Company do
     end
 
     context 'when it is a has many relationship' do
-      let(:scope) { HasManyUsers }
+      let(:user_model) { HasManyUsers::User }
+      let(:company_model) { HasManyUsers::Company }
 
       before do
         company.users << user
@@ -73,7 +85,8 @@ RSpec.describe Userlist::Rails::Transforms::Company do
     end
 
     context 'when it is a has one relationship' do
-      let(:scope) { HasOneUser }
+      let(:user_model) { HasOneUser::User }
+      let(:company_model) { HasOneUser::Company }
 
       before do
         company.user = user
@@ -85,7 +98,8 @@ RSpec.describe Userlist::Rails::Transforms::Company do
     end
 
     context 'when it is a belongs to relationship' do
-      let(:scope) { HasManyCompanies }
+      let(:user_model) { HasManyCompanies::User }
+      let(:company_model) { HasManyCompanies::Company }
 
       before do
         company.user = user

--- a/spec/userlist/rails/transforms/company_spec.rb
+++ b/spec/userlist/rails/transforms/company_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+RSpec.describe Userlist::Rails::Transforms::Company do
+  let(:config) { Userlist.config.merge(company_model: Company) }
+  let(:company) { Company.create(name: 'Example, Inc.') }
+
+  subject { described_class.new(company, config) }
+
+  describe '#identifier' do
+    it 'should generate a default identifier' do
+      expect(subject.identifier).to eq("company-#{company.id}")
+    end
+
+    it 'should use the userlist_identifier method' do
+      company.define_singleton_method(:userlist_identifier) { 'test-identifier' }
+      expect(subject.identifier).to eq('test-identifier')
+    end
+  end
+
+  describe '#properties' do
+    it 'should generate a default properties hash' do
+      expect(subject.properties).to eq({})
+    end
+
+    it 'should use the userlist_properties method' do
+      company.define_singleton_method(:userlist_properties) { { testing: true } }
+      expect(subject.properties).to eq({ testing: true })
+    end
+  end
+
+  describe '#name' do
+    it 'should use the models name column' do
+      expect(subject.name).to eq(company.name)
+    end
+
+    it 'should use the userlist_name method' do
+      company.define_singleton_method(:userlist_name) { 'Test, Inc.' }
+      expect(subject.name).to eq('Test, Inc.')
+    end
+  end
+
+  describe '#signed_up_at' do
+    it 'should use the created_at attribute as signed_up_at method' do
+      expect(subject.signed_up_at).to eq(company.created_at)
+    end
+  end
+
+  describe '#relationships' do
+    let(:config) { Userlist.config.merge(user_model: scope::User, company_model: scope::Company) }
+    let(:company) { scope::Company.create(name: 'Example, Inc.') }
+    let(:user) { scope::User.create(email: 'foo@example.com') }
+
+    context 'when it is a has many through relationship' do
+      let(:scope) { HasManyThrough }
+
+      before do
+        config.relationship_model = scope::Membership
+        company.memberships.create!(user: user)
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq(company.memberships)
+      end
+    end
+
+    context 'when it is a has and belongs to many relationship' do
+      let(:scope) { HasAndBelongsToMany }
+
+      before do
+        company.users << user
+
+        puts company.users.inspect
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq(company.users.map { |user| { user: user } })
+      end
+    end
+
+    context 'when it is a has many relationship' do
+      let(:scope) { HasManyUsers }
+
+      before do
+        company.users << user
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq(company.users.map { |user| { user: user } })
+      end
+    end
+
+    context 'when it is a has one relationship' do
+      let(:scope) { HasOneUser }
+
+      before do
+        company.user = user
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq([{ user: company.user }])
+      end
+    end
+
+    context 'when it is a belongs to relationship' do
+      let(:scope) { HasManyCompanies }
+
+      before do
+        company.user = user
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq([{ user: company.user }])
+      end
+    end
+  end
+end

--- a/spec/userlist/rails/transforms/user_spec.rb
+++ b/spec/userlist/rails/transforms/user_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+RSpec.describe Userlist::Rails::Transforms::User do
+  let(:config) { Userlist.config.merge(user_model: User) }
+  let(:user) { User.create(email: 'foo@example.com') }
+
+  subject { described_class.new(user, config) }
+
+  describe '#identifier' do
+    it 'should generate a default identifier' do
+      expect(subject.identifier).to eq("user-#{user.id}")
+    end
+
+    it 'should use the userlist_identifier method' do
+      user.define_singleton_method(:userlist_identifier) { 'test-identifier' }
+      expect(subject.identifier).to eq('test-identifier')
+    end
+  end
+
+  describe '#properties' do
+    it 'should generate a default properties hash' do
+      expect(subject.properties).to eq({})
+    end
+
+    it 'should use the userlist_properties method' do
+      user.define_singleton_method(:userlist_properties) { { testing: true } }
+      expect(subject.properties).to eq({ testing: true })
+    end
+  end
+
+  describe '#email' do
+    it 'should use the users email column' do
+      expect(subject.email).to eq(user.email)
+    end
+
+    it 'should use the userlist_email method' do
+      user.define_singleton_method(:userlist_email) { 'test@example.org' }
+      expect(subject.email).to eq('test@example.org')
+    end
+  end
+
+  describe '#signed_up_at' do
+    it 'should use the created_at attribute as signed_up_at method' do
+      expect(subject.signed_up_at).to eq(user.created_at)
+    end
+  end
+
+  describe '#relationships' do
+    let(:config) { Userlist.config.merge(user_model: scope::User, company_model: scope::Company) }
+    let(:user) { scope::User.create(email: 'foo@example.com') }
+    let(:company) { scope::Company.create(name: 'Example, Inc.') }
+
+    context 'when it is a has many through relationship' do
+      let(:scope) { HasManyThrough }
+
+      before do
+        config.relationship_model = scope::Membership
+        user.memberships.create!(company: company)
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq(user.memberships)
+      end
+    end
+
+    context 'when it is a has and belongs to many relationship' do
+      let(:scope) { HasAndBelongsToMany }
+
+      before do
+        user.companies << company
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq(user.companies.map { |company| { company: company } })
+      end
+    end
+
+    context 'when it is a has many relationship' do
+      let(:scope) { HasManyCompanies }
+
+      before do
+        user.companies << company
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq(user.companies.map { |company| { company: company } })
+      end
+    end
+
+    context 'when it is a has one relationship' do
+      let(:scope) { HasOneCompany }
+
+      before do
+        user.company = company
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq([{ company: user.company }])
+      end
+    end
+
+    context 'when it is a belongs to relationship' do
+      let(:scope) { HasManyUsers }
+
+      before do
+        user.company = company
+      end
+
+      it 'should return the relationships' do
+        expect(subject.relationships).to eq([{ company: user.company }])
+      end
+    end
+  end
+end

--- a/spec/userlist/rails/transforms/user_spec.rb
+++ b/spec/userlist/rails/transforms/user_spec.rb
@@ -31,15 +31,25 @@ RSpec.describe Userlist::Rails::Transforms::User do
   end
 
   describe '#default_relationships' do
-    let(:config) { Userlist.config.merge(user_model: scope::User, company_model: scope::Company) }
-    let(:user) { scope::User.create(email: 'foo@example.com') }
-    let(:company) { scope::Company.create(name: 'Example, Inc.') }
+    let(:config) { Userlist.config.merge(user_model: user_model, company_model: company_model) }
+    let(:user) { user_model.create(email: 'foo@example.com') }
+    let(:company) { company_model.create(name: 'Example, Inc.') }
+
+    context 'when there are no relationships' do
+      let(:user_model) { User }
+      let(:company_model) { Company }
+
+      it 'should return nothing' do
+        expect(subject.default_relationships).to_not be
+      end
+    end
 
     context 'when it is a has many through relationship' do
-      let(:scope) { HasManyThrough }
+      let(:user_model) { HasManyThrough::User }
+      let(:company_model) { HasManyThrough::Company }
 
       before do
-        config.relationship_model = scope::Membership
+        config.relationship_model = HasManyThrough::Membership
         user.memberships.create!(company: company)
       end
 
@@ -49,7 +59,8 @@ RSpec.describe Userlist::Rails::Transforms::User do
     end
 
     context 'when it is a has and belongs to many relationship' do
-      let(:scope) { HasAndBelongsToMany }
+      let(:user_model) { HasAndBelongsToMany::User }
+      let(:company_model) { HasAndBelongsToMany::Company }
 
       before do
         user.companies << company
@@ -61,7 +72,8 @@ RSpec.describe Userlist::Rails::Transforms::User do
     end
 
     context 'when it is a has many relationship' do
-      let(:scope) { HasManyCompanies }
+      let(:user_model) { HasManyCompanies::User }
+      let(:company_model) { HasManyCompanies::Company }
 
       before do
         user.companies << company
@@ -73,7 +85,8 @@ RSpec.describe Userlist::Rails::Transforms::User do
     end
 
     context 'when it is a has one relationship' do
-      let(:scope) { HasOneCompany }
+      let(:user_model) { HasManyUsers::User }
+      let(:company_model) { HasManyUsers::Company }
 
       before do
         user.company = company
@@ -85,7 +98,8 @@ RSpec.describe Userlist::Rails::Transforms::User do
     end
 
     context 'when it is a belongs to relationship' do
-      let(:scope) { HasManyUsers }
+      let(:user_model) { HasManyUsers::User }
+      let(:company_model) { HasManyUsers::Company }
 
       before do
         user.company = company

--- a/spec/userlist/rails/transforms/user_spec.rb
+++ b/spec/userlist/rails/transforms/user_spec.rb
@@ -6,46 +6,31 @@ RSpec.describe Userlist::Rails::Transforms::User do
 
   subject { described_class.new(user, config) }
 
-  describe '#identifier' do
+  describe '#default_identifier' do
     it 'should generate a default identifier' do
-      expect(subject.identifier).to eq("user-#{user.id}")
-    end
-
-    it 'should use the userlist_identifier method' do
-      user.define_singleton_method(:userlist_identifier) { 'test-identifier' }
-      expect(subject.identifier).to eq('test-identifier')
+      expect(subject.default_identifier).to eq("user-#{user.id}")
     end
   end
 
-  describe '#properties' do
+  describe '#default_properties' do
     it 'should generate a default properties hash' do
-      expect(subject.properties).to eq({})
-    end
-
-    it 'should use the userlist_properties method' do
-      user.define_singleton_method(:userlist_properties) { { testing: true } }
-      expect(subject.properties).to eq({ testing: true })
+      expect(subject.default_properties).to eq({})
     end
   end
 
-  describe '#email' do
+  describe '#default_email' do
     it 'should use the users email column' do
-      expect(subject.email).to eq(user.email)
-    end
-
-    it 'should use the userlist_email method' do
-      user.define_singleton_method(:userlist_email) { 'test@example.org' }
-      expect(subject.email).to eq('test@example.org')
+      expect(subject.default_email).to eq(user.email)
     end
   end
 
-  describe '#signed_up_at' do
+  describe '#default_signed_up_at' do
     it 'should use the created_at attribute as signed_up_at method' do
-      expect(subject.signed_up_at).to eq(user.created_at)
+      expect(subject.default_signed_up_at).to eq(user.created_at)
     end
   end
 
-  describe '#relationships' do
+  describe '#default_relationships' do
     let(:config) { Userlist.config.merge(user_model: scope::User, company_model: scope::Company) }
     let(:user) { scope::User.create(email: 'foo@example.com') }
     let(:company) { scope::Company.create(name: 'Example, Inc.') }
@@ -59,7 +44,7 @@ RSpec.describe Userlist::Rails::Transforms::User do
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq(user.memberships)
+        expect(subject.default_relationships).to eq(user.memberships)
       end
     end
 
@@ -71,7 +56,7 @@ RSpec.describe Userlist::Rails::Transforms::User do
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq(user.companies.map { |company| { company: company } })
+        expect(subject.default_relationships).to eq(user.companies.map { |company| { company: company } })
       end
     end
 
@@ -83,7 +68,7 @@ RSpec.describe Userlist::Rails::Transforms::User do
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq(user.companies.map { |company| { company: company } })
+        expect(subject.default_relationships).to eq(user.companies.map { |company| { company: company } })
       end
     end
 
@@ -95,7 +80,7 @@ RSpec.describe Userlist::Rails::Transforms::User do
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq([{ company: user.company }])
+        expect(subject.default_relationships).to eq([{ company: user.company }])
       end
     end
 
@@ -107,7 +92,7 @@ RSpec.describe Userlist::Rails::Transforms::User do
       end
 
       it 'should return the relationships' do
-        expect(subject.relationships).to eq([{ company: user.company }])
+        expect(subject.default_relationships).to eq([{ company: user.company }])
       end
     end
   end

--- a/spec/userlist/rails_spec.rb
+++ b/spec/userlist/rails_spec.rb
@@ -52,9 +52,49 @@ RSpec.describe Userlist::Rails do
   end
 
   describe '.detect_relationship' do
-    it 'should detect the relationship model between to other models' do
-      relationship = described_class.detect_relationship(User, Company)
-      expect(relationship).to eq(Membership)
+    context 'when it is a has many through relationship' do
+      let(:scope) { HasManyThrough }
+
+      it 'should detect the relationship model between to other models' do
+        relationship = described_class.detect_relationship(scope::User, scope::Company)
+        expect(relationship).to eq(scope::Membership)
+      end
+    end
+
+    context 'when it is a has and belongs to many relationship' do
+      let(:scope) { HasAndBelongsToMany }
+
+      it 'should not detect a relationship model between to other models' do
+        relationship = described_class.detect_relationship(scope::User, scope::Company)
+        expect(relationship).to eq(nil)
+      end
+    end
+
+    context 'when it is a has many relationship' do
+      let(:scope) { HasManyCompanies }
+
+      it 'should not detect a relationship model between to other models' do
+        relationship = described_class.detect_relationship(scope::User, scope::Company)
+        expect(relationship).to eq(nil)
+      end
+    end
+
+    context 'when it is a has one relationship' do
+      let(:scope) { HasOneCompany }
+
+      it 'should not detect a relationship model between to other models' do
+        relationship = described_class.detect_relationship(scope::User, scope::Company)
+        expect(relationship).to eq(nil)
+      end
+    end
+
+    context 'when it is a belongs to relationship' do
+      let(:scope) { HasManyUsers }
+
+      it 'should not detect a relationship model between to other models' do
+        relationship = described_class.detect_relationship(scope::User, scope::Company)
+        expect(relationship).to eq(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, the gem would only detect `has_many through:` associations. This pull request adds support for `belongs_to`, `has_one`, `has_many`, and `has_and_belongs_to_many` associations.

Thanks a lot to @swanson for the collaboration. 